### PR TITLE
Fixing direction  & Changing Naming Conventions

### DIFF
--- a/MPU/include/cascadiamc.h
+++ b/MPU/include/cascadiamc.h
@@ -12,7 +12,7 @@
 
 #define NOT_SPINNING_TORQUE_LIMIT   1500
 
-class CASCADIAMC
+class CascadiaMC
 {
     private:
 
@@ -49,9 +49,9 @@ class CASCADIAMC
         void disableMCLockout();
 
     public:
-        CASCADIAMC();
+        CascadiaMC();
 
-        ~CASCADIAMC();
+        ~CascadiaMC();
 
         /**
          * @brief Writes the desired state of the motor controller using the saved config

--- a/MPU/include/driverio.h
+++ b/MPU/include/driverio.h
@@ -26,11 +26,11 @@
  * @brief Class for handling all Driver IO functionality
  * 
  */
-class DRIVERIO
+class DriverIO
 {
     private:
-        CASCADIAMC *motorController;
-        ORIONBMS *bms;
+        CascadiaMC *motorController;
+        OrionBMS *bms;
 
         SPEAKER speaker {SPEAKER_PIN};
         LED socLED {LED4_PIN};
@@ -45,11 +45,11 @@ class DRIVERIO
         Timer powerToggle_wait;
 
     public:
-        DRIVERIO();
+        DriverIO();
 
-        DRIVERIO(CASCADIAMC *motorController, ORIONBMS *p_bms);
+        DriverIO(CascadiaMC *motorController, OrionBMS *p_bms);
 
-        ~DRIVERIO();
+        ~DriverIO();
 
         /**
          * @brief Debounces the Start/Stop button and toggles the power depending on if the button was pushed

--- a/MPU/include/driverio.h
+++ b/MPU/include/driverio.h
@@ -32,12 +32,12 @@ class DriverIO
         CascadiaMC *motorController;
         OrionBMS *bms;
 
-        SPEAKER speaker {SPEAKER_PIN};
+        Speaker speaker {SPEAKER_PIN};
         LED socLED {LED4_PIN};
         LED tempLED {LED5_PIN};
         LED yLED {YLED_PIN};
-        STARTBUTTON ssButton {SS_LED_PIN, SS_BUTT_PIN};
-        SWITCH reverseSwitch {REVERSE_SW_PIN};
+        StartButton ssButton {SS_LED_PIN, SS_BUTT_PIN};
+        Switch reverseSwitch {REVERSE_SW_PIN};
         
         //For future development and integration with Raspberry Pi
         //DASHBOARD dashboard;

--- a/MPU/include/driverioHW.h
+++ b/MPU/include/driverioHW.h
@@ -21,15 +21,15 @@ typedef enum ButtonState_t
 } ButtonState_t;
 
 
-class DASHBOARD
+class Dashboard
 {
     public:
-        DASHBOARD();
-        ~DASHBOARD();
+        Dashboard();
+        ~Dashboard();
 };
 
 
-class BUTTON
+class Button
 {
     private:
         ButtonState_t state = NOT_PRESSED;
@@ -37,8 +37,8 @@ class BUTTON
         uint8_t pin;
 
     public:
-        BUTTON(uint8_t pinNumber);
-        virtual ~BUTTON();
+        Button(uint8_t pinNumber);
+        virtual ~Button();
 
         /**
          * @brief Checks the state of the passed button pin and starts debounce if going from 0->1
@@ -64,16 +64,16 @@ class BUTTON
 };
 
 
-class SWITCH
+class Switch
 {
     private:
         uint8_t pin;
         bool previousReading;
 
     public:
-        SWITCH(uint8_t pinNumber);
+        Switch(uint8_t pinNumber);
         
-        ~SWITCH();
+        ~Switch();
 
         /**
          * @brief Get the current reading of the switch pin
@@ -123,7 +123,7 @@ class LED
 };
 
 
-class SPEAKER
+class Speaker
 {
     private:
         Timer waitTime;
@@ -132,9 +132,9 @@ class SPEAKER
         void writeSpeaker(bool state);
 
     public:
-        SPEAKER();
-        SPEAKER(uint8_t pinNumber);
-        ~SPEAKER();
+        Speaker();
+        Speaker(uint8_t pinNumber);
+        ~Speaker();
 
         /**
          * @brief start the speaker sound and speaker time
@@ -148,11 +148,11 @@ class SPEAKER
 };
 
 
-class STARTBUTTON: public BUTTON, public LED
+class StartButton: public Button, public LED
 {
     public:
-        STARTBUTTON(uint8_t ledPinNumber, uint8_t buttonPinNumber);
-        ~STARTBUTTON();
+        StartButton(uint8_t ledPinNumber, uint8_t buttonPinNumber);
+        ~StartButton();
 };
 
 #endif

--- a/MPU/include/gpio.h
+++ b/MPU/include/gpio.h
@@ -21,8 +21,8 @@ class GPIO
 {
     private:
         
-        RADIATORFAN radiatorFan;
-        COOLINGPUMP coolingPump;
+        RadiatorFan radiatorFan;
+        CoolingPump coolingPump;
         TSMS tsms;
 
         CascadiaMC *motorController;

--- a/MPU/include/gpio.h
+++ b/MPU/include/gpio.h
@@ -25,13 +25,13 @@ class GPIO
         COOLINGPUMP coolingPump;
         TSMS tsms;
 
-        CASCADIAMC *motorController;
-        ORIONBMS *bms;
+        CascadiaMC *motorController;
+        OrionBMS *bms;
 
     public:
         GPIO();
 
-        GPIO(CASCADIAMC *p_motorController, ORIONBMS *p_bms);
+        GPIO(CascadiaMC *p_motorController, OrionBMS *p_bms);
 
         ~GPIO();
 

--- a/MPU/include/gpioHW.h
+++ b/MPU/include/gpioHW.h
@@ -8,16 +8,16 @@
 
 #include <nerduino.h>
 
-class RADIATORFAN
+class RadiatorFan
 {
     private:
         bool isEnabled = true;
         uint8_t pin;
 
     public:
-        RADIATORFAN();
-        RADIATORFAN(uint8_t pinNum);
-        ~RADIATORFAN();
+        RadiatorFan();
+        RadiatorFan(uint8_t pinNum);
+        ~RadiatorFan();
 
         /**
          * @brief Enables/disables the fan entirely
@@ -28,17 +28,17 @@ class RADIATORFAN
 };
 
 
-class COOLINGPUMP
+class CoolingPump
 {
     private:
         bool isEnabled = true;
         uint8_t pin;
 
     public:
-        COOLINGPUMP();
-        COOLINGPUMP(uint8_t pinNum);
+        CoolingPump();
+        CoolingPump(uint8_t pinNum);
 
-        ~COOLINGPUMP();
+        ~CoolingPump();
 
         /**
          * @brief Enables/disables the pump

--- a/MPU/include/mpu.h
+++ b/MPU/include/mpu.h
@@ -13,11 +13,11 @@
 #include "orionbms.h"
 #include "Watchdog_t4.h"
 
-extern DRIVERIO driverio;
+extern DriverIO driverio;
 extern GPIO gpio;
-extern PEDALS pedals;
-extern CASCADIAMC motorController;
-extern ORIONBMS bms;
+extern Pedals pedals;
+extern CascadiaMC motorController;
+extern OrionBMS bms;
 
 extern WDT_T4<WDT1> wdt;
 

--- a/MPU/include/orionbms.h
+++ b/MPU/include/orionbms.h
@@ -20,7 +20,7 @@ enum
     AIR_OPEN
 };
 
-class ORIONBMS
+class OrionBMS
 {
     private:
         uint8_t SoC;
@@ -40,9 +40,9 @@ class ORIONBMS
         uint8_t OPEN_AIR_MSG[8] = {0x01,0x00,0x01,0x00,0x00,0xAA,0x00,0x00};
 
     public:
-        ORIONBMS();
+        OrionBMS();
 
-        ~ORIONBMS();
+        ~OrionBMS();
 
 /***************************************************************
  * Functions for Handling Errors and Warnings

--- a/MPU/include/pedalHW.h
+++ b/MPU/include/pedalHW.h
@@ -18,7 +18,7 @@
 #define BRAKELIGHT_MIN_TIME_ON      250 //ms
 #define NOT_DONE_READING            0xFFFF
 
-class PEDAL_HW
+class PedalHW
 {
     private:
         //Pedal reading timers
@@ -51,16 +51,16 @@ class PEDAL_HW
         void checkForPedalError(uint16_t val1, uint16_t val2);
 
     public:
-        PEDAL_HW();
+        PedalHW();
 
         /**
          * @brief Construct a new pedal hw object (requires pedal specific parameters)
          * @param errorPercent
          * @param maxErrors
          */
-        PEDAL_HW(float p_errorPercent, uint8_t p_maxErrors, uint8_t *pinNumbers);
+        PedalHW(float p_errorPercent, uint8_t p_maxErrors, uint8_t *pinNumbers);
 
-        ~PEDAL_HW();
+        ~PedalHW();
 
         /**
          * @brief Reads the current pedal value with error-checking and accuracy debounce

--- a/MPU/include/pedals.h
+++ b/MPU/include/pedals.h
@@ -53,8 +53,8 @@ class Pedals
         CascadiaMC *motorController;
         OrionBMS *bms;
 
-        PEDAL_HW brakes;
-        PEDAL_HW accelerator;
+        PedalHW brakes;
+        PedalHW accelerator;
 
         BRAKELIGHT_HW brakeLight;
 

--- a/MPU/include/pedals.h
+++ b/MPU/include/pedals.h
@@ -44,14 +44,14 @@
 #define ANALOG_BRAKE_THRESH         185
 #define MAXIMUM_BRAKE               255
 
-class PEDALS
+class Pedals
 {
     private:
         bool brakePressed = false;
         uint32_t timeBrake = 0;     // the time at which the brake was last pressed
 
-        CASCADIAMC *motorController;
-        ORIONBMS *bms;
+        CascadiaMC *motorController;
+        OrionBMS *bms;
 
         PEDAL_HW brakes;
         PEDAL_HW accelerator;
@@ -86,11 +86,11 @@ class PEDALS
         int16_t calcCLRegenLimit();
 
     public:
-        PEDALS();
+        Pedals();
 
-        PEDALS(CASCADIAMC *p_motorController, ORIONBMS *p_bms);
+        Pedals(CascadiaMC *p_motorController, OrionBMS *p_bms);
 
-        ~PEDALS();
+        ~Pedals();
 
         /**
          * @brief Reads the status of the brake, and sets brakePressed to True if it is pressed

--- a/MPU/src/cascadiamc.cpp
+++ b/MPU/src/cascadiamc.cpp
@@ -1,16 +1,16 @@
 #include "cascadiamc.h"
 
 
-CASCADIAMC::CASCADIAMC()
+CascadiaMC::CascadiaMC()
 {
     motorCommand_wait.cancelTimer();
 }
 
 
-CASCADIAMC::~CASCADIAMC(){}
+CascadiaMC::~CascadiaMC(){}
 
 
-void CASCADIAMC::disableMCLockout()
+void CascadiaMC::disableMCLockout()
 {
     while(!motorCommand_wait.isTimerExpired()){}
 
@@ -21,7 +21,7 @@ void CASCADIAMC::disableMCLockout()
 }
 
 
-void CASCADIAMC::writeMCState()
+void CascadiaMC::writeMCState()
 {
     if(isMCLocked)
     {
@@ -45,7 +45,7 @@ void CASCADIAMC::writeMCState()
 }
 
 
-void CASCADIAMC::toggleDirection()
+void CascadiaMC::toggleDirection()
 {
     if (mcMsg.config.isOn) {
         togglePower();
@@ -53,7 +53,7 @@ void CASCADIAMC::toggleDirection()
     mcMsg.config.isForward = !mcMsg.config.isForward;
 }
 
-void CASCADIAMC::setDirection(bool p_direction)
+void CascadiaMC::setDirection(bool p_direction)
 {
     if (mcMsg.config.isOn) {
         togglePower();
@@ -62,39 +62,38 @@ void CASCADIAMC::setDirection(bool p_direction)
 }
 
 
-void CASCADIAMC::togglePower()
+void CascadiaMC::togglePower()
 {
     mcMsg.config.isOn = !mcMsg.config.isOn;
     isMCLocked = true;
-    Serial.println(mcMsg.config.isOn);
 }
 
 
-bool CASCADIAMC::getIsOn()
+bool CascadiaMC::getIsOn()
 {
     return mcMsg.config.isOn;
 }
 
 
-bool CASCADIAMC::getDirection()
+bool CascadiaMC::getDirection()
 {
     return mcMsg.config.isForward;
 }
 
 
-void CASCADIAMC::changeTorque(uint16_t p_accelTorque)
+void CascadiaMC::changeTorque(uint16_t p_accelTorque)
 {
     mcMsg.config.accelTorque = p_accelTorque;
 }
 
 
-uint16_t CASCADIAMC::getTorque()
+uint16_t CascadiaMC::getTorque()
 {
     return mcMsg.config.accelTorque;
 }
 
 
-void CASCADIAMC::clearFault()
+void CascadiaMC::clearFault()
 {
     int time = millis() + 250;
     while(millis() < time) {
@@ -105,7 +104,7 @@ void CASCADIAMC::clearFault()
 }
 
 
-void CASCADIAMC::raiseFault()
+void CascadiaMC::raiseFault()
 {
     if (isFaulted == false) {
         Serial.println("CUCK");
@@ -115,13 +114,13 @@ void CASCADIAMC::raiseFault()
 }
 
 
-bool CASCADIAMC::checkFault()
+bool CascadiaMC::checkFault()
 {
     return isFaulted;
 }
 
 
-void CASCADIAMC::emergencyShutdown()
+void CascadiaMC::emergencyShutdown()
 {
     mcMsg.config.isOn = false;
     mcMsg.config.accelTorque = 0;
@@ -129,34 +128,34 @@ void CASCADIAMC::emergencyShutdown()
 }
 
 
-void CASCADIAMC::setMotorSpeed(int16_t p_motorSpeed)
+void CascadiaMC::setMotorSpeed(int16_t p_motorSpeed)
 {
     motorSpeed = p_motorSpeed;
 }
 
-bool CASCADIAMC::isMotorMoving()
+bool CascadiaMC::isMotorMoving()
 {
     return abs(motorSpeed) > 0;
 }
 
 
-bool CASCADIAMC::shouldMotorBeSpinning()
+bool CascadiaMC::shouldMotorBeSpinning()
 {
     return mcMsg.config.accelTorque > NOT_SPINNING_TORQUE_LIMIT;
 }
 
 
-int16_t CASCADIAMC::getMotorSpeed()
+int16_t CascadiaMC::getMotorSpeed()
 {
     return motorSpeed;
 }
 
-void CASCADIAMC::setRadiatorTemp(int16_t temp)
+void CascadiaMC::setRadiatorTemp(int16_t temp)
 {
     radiatorTemp = temp;
 }
 
-int16_t CASCADIAMC::getRadiatorTemp()
+int16_t CascadiaMC::getRadiatorTemp()
 {
     return radiatorTemp;
 }

--- a/MPU/src/driverio.cpp
+++ b/MPU/src/driverio.cpp
@@ -1,22 +1,24 @@
 #include "driverio.h"
 #include <nerduino.h>
 
-DRIVERIO::DRIVERIO(){}
+DriverIO::DriverIO(){}
 
 
-DRIVERIO::DRIVERIO(CASCADIAMC *p_motorController, ORIONBMS *p_bms)
+DriverIO::DriverIO(CascadiaMC *p_motorController, OrionBMS *p_bms)
 {
     powerToggle_wait.cancelTimer();
 
     motorController = p_motorController;
     bms = p_bms;
+
+    motorController->setDirection(reverseSwitch.getSwitchState());
 }
 
 
-DRIVERIO::~DRIVERIO(){}
+DriverIO::~DriverIO(){}
 
 
-void DRIVERIO::handleSSButtonPress()
+void DriverIO::handleSSButtonPress()
 {
     //Poll Button
     ssButton.checkButtonPin();
@@ -39,7 +41,6 @@ void DRIVERIO::handleSSButtonPress()
     if(motorController->getIsOn() || 
         (!motorController->getIsOn() && !motorController->checkFault()))
     {
-        Serial.println("TOGGLE");
         motorController->togglePower();    //Writes the power state of the motor to the MC message to be sent
         if(motorController->getIsOn())
         {
@@ -51,7 +52,7 @@ void DRIVERIO::handleSSButtonPress()
 }
 
 
-void DRIVERIO::handleSSLED()
+void DriverIO::handleSSLED()
 {
     if(bms->getChargeMode())
     {
@@ -64,17 +65,18 @@ void DRIVERIO::handleSSLED()
 }
 
 
-void DRIVERIO::handleReverseSwitch()
+void DriverIO::handleReverseSwitch()
 {
     if(reverseSwitch.hasSwitchToggled())
     {
-        Serial.println("REVERSE");
         motorController->setDirection(reverseSwitch.getSwitchState());
+        Serial.println(motorController->getDirection());
+        Serial.println(".");
     }  
 }
 
 
-void DRIVERIO::handleErrorLights()
+void DriverIO::handleErrorLights()
 {
     tempLED.updateBlink();
 

--- a/MPU/src/driverioHW.cpp
+++ b/MPU/src/driverioHW.cpp
@@ -168,7 +168,7 @@ bool SWITCH::getSwitchState()
 bool SWITCH::hasSwitchToggled()
 {
     if(getSwitchState() == previousReading) return false;
-
+    
     previousReading = getSwitchState();
     return true;
 }

--- a/MPU/src/driverioHW.cpp
+++ b/MPU/src/driverioHW.cpp
@@ -7,16 +7,16 @@
  */
 /**************************************************************************************/
 
-BUTTON::BUTTON(uint8_t pinNumber)
+Button::Button(uint8_t pinNumber)
 {
     pin = pinNumber;
     pinMode(pin, INPUT_PULLUP);
     debounce.cancelTimer();
 }
 
-BUTTON::~BUTTON(){}
+Button::~Button(){}
 
-void BUTTON::checkButtonPin()
+void Button::checkButtonPin()
 {
     if(digitalRead(pin) == HIGH && state == NOT_PRESSED)
     {
@@ -30,7 +30,7 @@ void BUTTON::checkButtonPin()
     }
 }
 
-bool BUTTON::isButtonPressed()
+bool Button::isButtonPressed()
 {
     if(state == PRESSED) return true;
 
@@ -48,7 +48,7 @@ bool BUTTON::isButtonPressed()
     return false;
 }
 
-bool BUTTON::isButtonPressed_Pulse()
+bool Button::isButtonPressed_Pulse()
 {
     if(state == PRESSED) return false;
 
@@ -77,7 +77,7 @@ bool BUTTON::isButtonPressed_Pulse()
  */
 /**************************************************************************************/
 
-SPEAKER::SPEAKER(uint8_t pinNumber)
+Speaker::Speaker(uint8_t pinNumber)
 {
     pin = pinNumber;
     pinMode(pin, OUTPUT);
@@ -85,21 +85,21 @@ SPEAKER::SPEAKER(uint8_t pinNumber)
     waitTime.cancelTimer();
 }
 
-SPEAKER::~SPEAKER(){}
+Speaker::~Speaker(){}
 
-void SPEAKER::writeSpeaker(bool state)
+void Speaker::writeSpeaker(bool state)
 {
     //We need to invert the logic of the speaker due to the hardware
     digitalWrite(pin,!state);
 }
 
-void SPEAKER::playSpeaker()
+void Speaker::playSpeaker()
 {
     writeSpeaker(HIGH);
     waitTime.startTimer(SPEAKER_DURATION);
 }
 
-void SPEAKER::attemptToStopSpeaker()
+void Speaker::attemptToStopSpeaker()
 {
     if(waitTime.isTimerExpired())
     {
@@ -150,22 +150,22 @@ void LED::updateBlink()
  */
 /**************************************************************************************/
 
-SWITCH::SWITCH(uint8_t pinNumber)
+Switch::Switch(uint8_t pinNumber)
 {
     pin = pinNumber;
     pinMode(pin,INPUT_PULLUP);
     previousReading = getSwitchState();
 }
 
-SWITCH::~SWITCH(){}
+Switch::~Switch(){}
 
-bool SWITCH::getSwitchState()
+bool Switch::getSwitchState()
 {
     bool switchReading = digitalRead(pin);
     return switchReading;
 }
 
-bool SWITCH::hasSwitchToggled()
+bool Switch::hasSwitchToggled()
 {
     if(getSwitchState() == previousReading) return false;
     
@@ -179,10 +179,10 @@ bool SWITCH::hasSwitchToggled()
  */
 /**************************************************************************************/
 
-STARTBUTTON::STARTBUTTON(uint8_t ledPinNumber, uint8_t buttonPinNumber)
-    : BUTTON(buttonPinNumber), LED(ledPinNumber) {}
+StartButton::StartButton(uint8_t ledPinNumber, uint8_t buttonPinNumber)
+    : Button(buttonPinNumber), LED(ledPinNumber) {}
 
-STARTBUTTON::~STARTBUTTON(){}
+StartButton::~StartButton(){}
 
 /**************************************************************************************/
 /**
@@ -190,7 +190,7 @@ STARTBUTTON::~STARTBUTTON(){}
  */
 /**************************************************************************************/
 
-DASHBOARD::DASHBOARD()
+Dashboard::Dashboard()
 {}
 
-DASHBOARD::~DASHBOARD(){}
+Dashboard::~Dashboard(){}

--- a/MPU/src/gpio.cpp
+++ b/MPU/src/gpio.cpp
@@ -5,8 +5,8 @@ GPIO::GPIO(){}
 
 GPIO::GPIO(CascadiaMC *p_motorController, OrionBMS *p_bms)
 {
-    radiatorFan = RADIATORFAN(RADIATORFAN_PIN);
-    coolingPump = COOLINGPUMP(PUMP_PIN);
+    radiatorFan = RadiatorFan(RADIATORFAN_PIN);
+    coolingPump = CoolingPump(PUMP_PIN);
     tsms = TSMS(SS_READY_SEN);
 
     motorController = p_motorController;

--- a/MPU/src/gpio.cpp
+++ b/MPU/src/gpio.cpp
@@ -3,7 +3,7 @@
 GPIO::GPIO(){}
 
 
-GPIO::GPIO(CASCADIAMC *p_motorController, ORIONBMS *p_bms)
+GPIO::GPIO(CascadiaMC *p_motorController, OrionBMS *p_bms)
 {
     radiatorFan = RADIATORFAN(RADIATORFAN_PIN);
     coolingPump = COOLINGPUMP(PUMP_PIN);

--- a/MPU/src/gpioHW.cpp
+++ b/MPU/src/gpioHW.cpp
@@ -1,35 +1,35 @@
 #include "gpioHW.h"
 
-RADIATORFAN::RADIATORFAN(){}
+RadiatorFan::RadiatorFan(){}
 
-RADIATORFAN::RADIATORFAN(uint8_t pinNum)
+RadiatorFan::RadiatorFan(uint8_t pinNum)
 {
     pin = pinNum;
     pinMode(pin, OUTPUT);
     enableFan(false);
 }
 
-RADIATORFAN::~RADIATORFAN(){}
+RadiatorFan::~RadiatorFan(){}
 
-void RADIATORFAN::enableFan(bool status)
+void RadiatorFan::enableFan(bool status)
 {
     isEnabled = status;
     digitalWrite(pin, isEnabled);
 }
 
 
-COOLINGPUMP::COOLINGPUMP(){}
+CoolingPump::CoolingPump(){}
 
-COOLINGPUMP::COOLINGPUMP(uint8_t pinNum)
+CoolingPump::CoolingPump(uint8_t pinNum)
 {
     pin = pinNum;
     pinMode(pin, OUTPUT);
     enablePump(false);
 }
 
-COOLINGPUMP::~COOLINGPUMP(){}
+CoolingPump::~CoolingPump(){}
 
-void COOLINGPUMP::enablePump(bool status)
+void CoolingPump::enablePump(bool status)
 {
     isEnabled = status;
     digitalWrite(pin, isEnabled);

--- a/MPU/src/main.cpp
+++ b/MPU/src/main.cpp
@@ -15,8 +15,8 @@ void setup()
     config.timeout = 15;        /* in seconds, 0->128 */
     wdt.begin(config);
 
-    pedals = PEDALS(&motorController, &bms);
-    driverio = DRIVERIO(&motorController, &bms);
+    pedals = Pedals(&motorController, &bms);
+    driverio = DriverIO(&motorController, &bms);
     gpio = GPIO(&motorController, &bms);
     pinMode(RELAY_PIN, OUTPUT);
     writeFaultLatch(NOT_FAULTED);

--- a/MPU/src/mpu.cpp
+++ b/MPU/src/mpu.cpp
@@ -1,10 +1,10 @@
 #include "mpu.h"
 
-DRIVERIO driverio;
+DriverIO driverio;
 GPIO gpio;
-PEDALS pedals;
-CASCADIAMC motorController;
-ORIONBMS bms;
+Pedals pedals;
+CascadiaMC motorController;
+OrionBMS bms;
 WDT_T4<WDT1> wdt;
 bool isShutdown = false;
 bool ssReady = false;

--- a/MPU/src/orionbms.cpp
+++ b/MPU/src/orionbms.cpp
@@ -1,123 +1,123 @@
 #include "orionbms.h"
 
-ORIONBMS::ORIONBMS()
+OrionBMS::OrionBMS()
 {
     boostRecharge_wait.cancelTimer();
     isInChargeMode.cancelTimer();
 }
 
 
-ORIONBMS::~ORIONBMS(){}
+OrionBMS::~OrionBMS(){}
 
 
-void ORIONBMS::setSoC(uint8_t p_SoC)
+void OrionBMS::setSoC(uint8_t p_SoC)
 {
     SoC = p_SoC;
 }
 
 
-void ORIONBMS::setAvgTemp(uint8_t p_avgTemp)
+void OrionBMS::setAvgTemp(uint8_t p_avgTemp)
 {
     avgTemp = p_avgTemp;
 }
 
 
-void ORIONBMS::setFailsafeCode(uint8_t p_failsafeCode)
+void OrionBMS::setFailsafeCode(uint8_t p_failsafeCode)
 {
     failsafeCode = p_failsafeCode;
 }
 
 
-uint8_t ORIONBMS::getSoC()
+uint8_t OrionBMS::getSoC()
 {
     return SoC;
 }
 
 
-bool ORIONBMS::isSoCCritical()
+bool OrionBMS::isSoCCritical()
 {
     return SoC < CRITICAL_SOC;
 }
 
 
-uint8_t ORIONBMS::getAvgTemp()
+uint8_t OrionBMS::getAvgTemp()
 {
     return avgTemp;
 }
 
 
-bool ORIONBMS::isAvgTempCritical()
+bool OrionBMS::isAvgTempCritical()
 {
     return avgTemp > CRITICAL_CELLTEMP;
 }
 
 
-bool ORIONBMS::isAvgTempShutdown()
+bool OrionBMS::isAvgTempShutdown()
 {
     return avgTemp > SHUTDOWN_CELLTEMP;
 }
 
 
-void ORIONBMS::setCurrentLimit(uint16_t p_currentLimit)
+void OrionBMS::setCurrentLimit(uint16_t p_currentLimit)
 {
     currentLimit = p_currentLimit;
 }
 
-void ORIONBMS::setChargeCurrentLimit(uint16_t p_chargeCurrentLimit)
+void OrionBMS::setChargeCurrentLimit(uint16_t p_chargeCurrentLimit)
 {
     chargeCurrentLimit = p_chargeCurrentLimit;
 }
 
 
-uint16_t ORIONBMS::getCurrentLimit()
+uint16_t OrionBMS::getCurrentLimit()
 {
     return currentLimit;
 }
 
 
-uint16_t ORIONBMS::getChargeCurrentLimit()
+uint16_t OrionBMS::getChargeCurrentLimit()
 {
     return chargeCurrentLimit;
 }
 
 
-void ORIONBMS::setCurrentDraw(int16_t p_currentDraw)
+void OrionBMS::setCurrentDraw(int16_t p_currentDraw)
 {
     currentDraw = p_currentDraw;
 }
 
 
-bool ORIONBMS::isCurrentPastLimit()
+bool OrionBMS::isCurrentPastLimit()
 {
     return currentDraw > currentLimit;
 }
 
 
-bool ORIONBMS::isCharging()
+bool OrionBMS::isCharging()
 {
     return currentDraw < 0;
 }
 
 
-void ORIONBMS::setLiveVoltage(int16_t p_voltage)
+void OrionBMS::setLiveVoltage(int16_t p_voltage)
 {
     liveVoltage = p_voltage;
 }
 
 
-int16_t ORIONBMS::getLiveVoltage()
+int16_t OrionBMS::getLiveVoltage()
 {
     return liveVoltage;
 }
 
 
-void ORIONBMS::enableChargingMode()
+void OrionBMS::enableChargingMode()
 {
     isInChargeMode.startTimer(2000);
 }
 
 
-bool ORIONBMS::getChargeMode()
+bool OrionBMS::getChargeMode()
 {
     if(isInChargeMode.isTimerExpired())
     {
@@ -128,14 +128,14 @@ bool ORIONBMS::getChargeMode()
 }
 
 
-void ORIONBMS::toggleAIR()
+void OrionBMS::toggleAIR()
 {
     airOpen = !airOpen;
     sendMessage(CANMSG_MC_SETPARAMETER, 8, airOpen ? OPEN_AIR_MSG : CLOSE_AIR_MSG);
 }
 
 
-bool ORIONBMS::isAIROpen()
+bool OrionBMS::isAIROpen()
 {
     return airOpen;
 }

--- a/MPU/src/pedalHW.cpp
+++ b/MPU/src/pedalHW.cpp
@@ -1,10 +1,10 @@
 #include "pedalHW.h"
 
-PEDAL_HW::PEDAL_HW(){}
+PedalHW::PedalHW(){}
 
-PEDAL_HW::~PEDAL_HW(){}
+PedalHW::~PedalHW(){}
 
-PEDAL_HW::PEDAL_HW(float p_errorPercent, uint8_t p_maxErrors, uint8_t *pinNumbers)
+PedalHW::PedalHW(float p_errorPercent, uint8_t p_maxErrors, uint8_t *pinNumbers)
 {
     errorPercent = p_errorPercent;
     maxErrors = p_maxErrors;
@@ -15,7 +15,7 @@ PEDAL_HW::PEDAL_HW(float p_errorPercent, uint8_t p_maxErrors, uint8_t *pinNumber
 	readingDebounce.cancelTimer();
 }
 
-uint16_t PEDAL_HW::readValue()
+uint16_t PedalHW::readValue()
 {
     //Acounting for first loop
     if(readingDebounce.isTimerReset()) readingDebounce.startTimer(PEDAL_DEBOUNCE_TIME);
@@ -31,7 +31,7 @@ uint16_t PEDAL_HW::readValue()
     return finalReading;
 }
 
-void PEDAL_HW::minimizingDiffDebounce()
+void PedalHW::minimizingDiffDebounce()
 {
     uint16_t pin1Val = analogRead(pin1);
     uint16_t pin2Val = analogRead(pin2);
@@ -45,7 +45,7 @@ void PEDAL_HW::minimizingDiffDebounce()
     checkForPedalError(pin1Val, pin2Val);
 }
 
-void PEDAL_HW::checkForPedalError(uint16_t val1, uint16_t val2)
+void PedalHW::checkForPedalError(uint16_t val1, uint16_t val2)
 {
     // Check for out of range values and errors (bottoming out of sensors/one faulty sensor)
     if (val1 == 0 ||
@@ -62,7 +62,7 @@ void PEDAL_HW::checkForPedalError(uint16_t val1, uint16_t val2)
     }
 }
 
-FaultStatus_t PEDAL_HW::isFaulted()
+FaultStatus_t PedalHW::isFaulted()
 {
     return readingFault;
 }

--- a/MPU/src/pedals.cpp
+++ b/MPU/src/pedals.cpp
@@ -1,10 +1,10 @@
 #include "pedals.h"
 
 
-PEDALS::PEDALS(){}
+Pedals::Pedals(){}
 
 
-PEDALS::PEDALS(CASCADIAMC *p_motorController, ORIONBMS *p_bms)
+Pedals::Pedals(CascadiaMC *p_motorController, OrionBMS *p_bms)
 {
 	pinMode(BRAKELIGHT_PIN, OUTPUT);
 	digitalWrite(BRAKELIGHT_PIN, HIGH);
@@ -18,10 +18,10 @@ PEDALS::PEDALS(CASCADIAMC *p_motorController, ORIONBMS *p_bms)
 }
 
 
-PEDALS::~PEDALS(){}
+Pedals::~Pedals(){}
 
 
-FaultStatus_t PEDALS::readAccel()
+FaultStatus_t Pedals::readAccel()
 {
 	//Begin or continue the pedal reading process
 	uint16_t pedalVal = accelerator.readValue();
@@ -57,7 +57,7 @@ FaultStatus_t PEDALS::readAccel()
 }
 
 
-FaultStatus_t PEDALS::readBrake()
+FaultStatus_t Pedals::readBrake()
 {
 	//Begin or continue the pedal reading process
 	uint16_t pedalVal = brakes.readValue();
@@ -77,7 +77,7 @@ FaultStatus_t PEDALS::readBrake()
 }
 
 
-int16_t PEDALS::calcTorque(double torqueScale)
+int16_t Pedals::calcTorque(double torqueScale)
 {
 	int16_t pedalTorque = 0;
 
@@ -109,7 +109,7 @@ int16_t PEDALS::calcTorque(double torqueScale)
 }
 
 
-int16_t PEDALS::calcCLTorqueLimit()
+int16_t Pedals::calcCLTorqueLimit()
 {
 	int16_t dcVoltage = abs(bms->getLiveVoltage());
 	int16_t dcCurrent = bms->getCurrentLimit();
@@ -141,7 +141,7 @@ int16_t PEDALS::calcCLTorqueLimit()
 }
 
 
-int16_t PEDALS::calcCLRegenLimit()
+int16_t Pedals::calcCLRegenLimit()
 {
 	int16_t dcVoltage = abs(bms->getLiveVoltage());
 	int16_t dcCurrent = bms->getChargeCurrentLimit();

--- a/MPU/src/pedals.cpp
+++ b/MPU/src/pedals.cpp
@@ -12,8 +12,8 @@ Pedals::Pedals(CascadiaMC *p_motorController, OrionBMS *p_bms)
 	motorController = p_motorController;
 	bms = p_bms;
 
-	accelerator = PEDAL_HW(ACCELERATOR_ERROR_PERCENT, MAX_ACCEL_ERRORS, accelPins);
-	brakes = PEDAL_HW(BRAKES_ERROR_PERCENT, MAX_BRAKE_ERRORS, brakePins);
+	accelerator = PedalHW(ACCELERATOR_ERROR_PERCENT, MAX_ACCEL_ERRORS, accelPins);
+	brakes = PedalHW(BRAKES_ERROR_PERCENT, MAX_BRAKE_ERRORS, brakePins);
 	brakeLight = BRAKELIGHT_HW(BRAKELIGHT_PIN);
 }
 


### PR DESCRIPTION
In this PR...
I've initialized the motor direction to the current reading of the switch status
Changing naming conventions of classes from CAPS to CamelCase