### PR TITLE
Add support for analog sensor read

### DIFF
--- a/TCU/include/logger.h
+++ b/TCU/include/logger.h
@@ -13,6 +13,7 @@
 #define LOGGER_ERROR_BUFFER_FULL 1
 #define LOGGER_ERROR_SD_CARD     2
 #define LOGGER_ERROR_NO_WRITE    3
+#define LOGGER_ERROR_NO_INIT     4
 
 
 typedef struct {
@@ -50,3 +51,11 @@ int LoggerBufferMessage(uint32_t id, uint8_t len, const uint8_t *buf);
  * @return int Status code
  */
 int LoggerWrite();
+
+
+/**
+ * @brief Finds whether the logger is currently logging messages
+ * 
+ * @return true when active, false otherwise
+ */
+bool LoggerActive();

--- a/TCU/src/logger.cpp
+++ b/TCU/src/logger.cpp
@@ -147,13 +147,23 @@ int LoggerInit(uint32_t logFrequency) {
 
 
 /**
+ * @brief Finds whether the logger is currently logging messages
+ * 
+ * @return true when active, false otherwise
+ */
+bool LoggerActive() {
+  return initialized;
+}
+
+
+/**
  * @brief Writes the messages currently buffered to the SD card. 
  * 
  * @return int Status code
  */
 int LoggerWrite() {
   if (!initialized) {
-    return LOGGER_ERROR_SD_CARD;
+    return LOGGER_ERROR_NO_INIT;
   }
 
   // find appropriate buffer to use
@@ -241,7 +251,7 @@ int LoggerWrite() {
  */
 int LoggerBufferMessage(uint32_t id, uint8_t len, const uint8_t *buf) {
   if (!initialized) {
-    return LOGGER_ERROR_SD_CARD;
+    return LOGGER_ERROR_NO_INIT;
   }
 
   noInterrupts();

--- a/TCU/src/main.cpp
+++ b/TCU/src/main.cpp
@@ -14,7 +14,7 @@
 
 #define MIN_LOG_FREQUENCY 1000 // the max time length between logs (in ms)
 
-#define ACCEL_HUMID_LOG_FREQUENCY 100 // time between logging accel/humid data
+#define ACCEL_HUMID_LOG_FREQUENCY 10 // time between logging accel/humid data
 #define ACCEL_LOG_ID 0x300
 #define HUMID_LOG_ID 0x301
 

--- a/TCU/src/main.cpp
+++ b/TCU/src/main.cpp
@@ -18,12 +18,12 @@
 #define ACCEL_LOG_ID 0x300
 #define HUMID_LOG_ID 0x301
 
-#define ANALOG1_PIN A0       // Pin 14 on teensy
-#define ANALOG1_LOG_ID 0x302
+#define ANALOG1_PIN A0 // Pin 14 on teensy
 #define ANALOG2_PIN A1       
-#define ANALOG2_LOG_ID 0x303
-#define ANALOG3_PIN A2      
-#define ANALOG3_LOG_ID 0x304
+#define ANALOG3_PIN A2 
+
+#define ANALOG1_LOG_ID      0x302  
+#define STRAIN_GAUGE_LOG_ID 0x303
 
 #define LED_BLINK_DELAY_MS 500
 
@@ -185,22 +185,19 @@ void logSensorData() {
  */
 void logAnalogs() {
   int analog1Value = (analogRead(ANALOG1_PIN) - 509) * 74054.326212; // 0.00488 / 0.066 * 10^6 scale factor
-  int analog2Value = analogRead(ANALOG2_PIN);
-  int analog3Value = analogRead(ANALOG3_PIN);
+  int analog2Value = analogRead(ANALOG2_PIN) * 3225.80645; // convert to 3.3V with 10^6 scale factor
+  int analog3Value = analogRead(ANALOG3_PIN) * 3225.80645;
 
   uint8_t analog1Buf[4] = {
     analog1Value & 255, (analog1Value >> 8) & 255, (analog1Value >> 16) & 255, (analog1Value >> 24) & 255
   };
-  uint8_t analog2Buf[2] = {
-    analog2Value & 255, (analog2Value >> 8) & 255
-  };
-  uint8_t analog3Buf[2] = {
-    analog3Value & 255, (analog3Value >> 8) & 255
+  uint8_t strainGaugeBuf[8] = {
+    analog2Value & 255, (analog2Value >> 8) & 255, (analog2Value >> 16) & 255, (analog2Value >> 24) & 255,
+    analog3Value & 255, (analog3Value >> 8) & 255, (analog3Value >> 16) & 255, (analog3Value >> 24) & 255
   };
 
   LoggerBufferMessage(ANALOG1_LOG_ID, 4, analog1Buf);
-  LoggerBufferMessage(ANALOG2_LOG_ID, 2, analog2Buf);
-  LoggerBufferMessage(ANALOG3_LOG_ID, 2, analog3Buf);
+  LoggerBufferMessage(STRAIN_GAUGE_LOG_ID, 8, strainGaugeBuf);
 }
 
 

--- a/TCU/src/main.cpp
+++ b/TCU/src/main.cpp
@@ -19,8 +19,8 @@
 #define HUMID_LOG_ID 0x301
 
 #define ANALOG1_PIN A0 // Pin 14 on teensy
-#define ANALOG2_PIN A1       
-#define ANALOG3_PIN A2 
+#define ANALOG2_PIN A6       
+#define ANALOG3_PIN A7 
 
 #define ANALOG1_LOG_ID      0x302  
 #define STRAIN_GAUGE_LOG_ID 0x303

--- a/TCU/src/main.cpp
+++ b/TCU/src/main.cpp
@@ -147,14 +147,16 @@ void logSensorData() {
     humidData[0].HumidData.rawdata[0], humidData[0].HumidData.rawdata[1]
   };
 
-  int analogValue = analogRead(ANALOG_PIN); // Value of 0 to 1023 for 0 to 5V
-  uint8_t analogBuf[2] = {
-    analogValue & 255, (analogValue >> 8) & 255, // Creates a little endian, 2 byte buffer to store a value from 0 to 1023
+  // Get current value and multiple by 10^6 to store in an int variable
+  int analogValue = analogRead(ANALOG_PIN) - 509;
+  int adjustedValue = analogValue * 74054.326212; // 0.00488 / 0.066 * 10^6 scale factor
+  uint8_t analogBuf[4] = {
+    adjustedValue & 255, (adjustedValue >> 8) & 255, (adjustedValue >> 16) & 255, (adjustedValue >> 24) & 255
   };
 
   LoggerBufferMessage(ACCEL_LOG_ID, 6, accelBuf);
   LoggerBufferMessage(HUMID_LOG_ID, 4, humidBuf);
-  LoggerBufferMessage(ANALOG_LOG_ID, 2, analogBuf);
+  LoggerBufferMessage(ANALOG_LOG_ID, 4, analogBuf);
 }
 
 /**

--- a/TCU/src/main.cpp
+++ b/TCU/src/main.cpp
@@ -18,6 +18,9 @@
 #define ACCEL_LOG_ID 0x300
 #define HUMID_LOG_ID 0x301
 
+#define ANALOG_PIN A0       // Pin 14 on teensy
+#define ANALOG_LOG_ID 0x302
+
 
 FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_16> myCan; // main CAN object
 WDT_T4<WDT1> wdt;
@@ -73,6 +76,8 @@ void setup() {
   myCan.enableFIFO(); 
   myCan.enableFIFOInterrupt(); 
   myCan.onReceive(incomingCANCallback);
+
+  pinMode(ANALOG_PIN, INPUT);
   
   // XbeeInit(&Serial1, 115200);
 
@@ -142,8 +147,14 @@ void logSensorData() {
     humidData[0].HumidData.rawdata[0], humidData[0].HumidData.rawdata[1]
   };
 
+  int analogValue = analogRead(ANALOG_PIN); // Value of 0 to 1023 for 0 to 5V
+  uint8_t analogBuf[2] = {
+    analogValue & 255, (analogValue >> 8) & 255, // Creates a little endian, 2 byte buffer to store a value from 0 to 1023
+  };
+
   LoggerBufferMessage(ACCEL_LOG_ID, 6, accelBuf);
   LoggerBufferMessage(HUMID_LOG_ID, 4, humidBuf);
+  LoggerBufferMessage(ANALOG_LOG_ID, 2, analogBuf);
 }
 
 /**


### PR DESCRIPTION
Add an analog input on teensy pin A0 (14). Logs this message with an ID of 0x302 in little-endian format (value of 0 to 1023). Will need to either process this value into a current value in this code or later in the Telemetry Hub.