### PR TITLE
Pdu integration

### DIFF
--- a/MPU/include/cascadiamc.h
+++ b/MPU/include/cascadiamc.h
@@ -110,12 +110,6 @@ class CascadiaMC
         uint16_t getTorque();
 
         /**
-         * @brief Clears the Fault for Failing to Generate High Voltage
-         * 
-         */
-        void clearFault();
-
-        /**
          * @brief Raises the Fault for Failing to Generate High Voltage
          * 
          */

--- a/MPU/include/driverio.h
+++ b/MPU/include/driverio.h
@@ -60,7 +60,7 @@ class DriverIO
          * @brief Debounces the increment and decrement buttons
          * 
          */
-        void handleButtonState();
+        void handleButtonState(bool tsms_status);
 
         /**
          * @brief Handles whether the speaker is playing or not

--- a/MPU/include/gpio.h
+++ b/MPU/include/gpio.h
@@ -19,18 +19,15 @@
 class GPIO
 {
     private:
-        
-        RadiatorFan radiatorFan;
-        CoolingPump coolingPump;
         TSMS tsms;
-
         CascadiaMC *motorController;
         OrionBMS *bms;
+        PDU *pdu;
 
     public:
         GPIO();
 
-        GPIO(CascadiaMC *p_motorController, OrionBMS *p_bms);
+        GPIO(CascadiaMC *p_motorController, OrionBMS *p_bms, PDU *p_pdu);
 
         ~GPIO();
 

--- a/MPU/include/gpio.h
+++ b/MPU/include/gpio.h
@@ -35,7 +35,7 @@ class GPIO
          * @brief Handles the case for the TSMS switching states
          * 
          */
-        bool handleTSMS();
+        bool getTSMS();
 
         /**
          * @brief Handles the logic behind starting/stopping the pump

--- a/MPU/include/gpioHW.h
+++ b/MPU/include/gpioHW.h
@@ -8,46 +8,40 @@
 
 #include <nerduino.h>
 
-class RadiatorFan
+#define CANMSG_PDU_ID 0x666
+
+class PDU
 {
     private:
-        bool isEnabled = true;
-        uint8_t pin;
+        union
+        {
+            uint8_t msg[5] = {0, 0, 0, 0, 0};
+
+            struct
+            {
+                bool brake_light;
+                bool cooling_pump;
+                bool left_acc_fan;
+                bool right_acc_fan;
+                uint8_t radiator_fan_dty;
+            } fields;
+        } pdu;
+
+        void sendPDUMsg();
 
     public:
-        RadiatorFan();
-        RadiatorFan(uint8_t pinNum);
-        ~RadiatorFan();
+        PDU();
 
-        /**
-         * @brief Enables/disables the fan entirely
-         * 
-         * @param status 
-         */
-        void enableFan(bool status);
+        ~PDU();
+
+        void enableRadiatorFan(bool status);
+
+        void enableAccFans(bool r_status, bool l_status);
+
+        void enableCoolingPump(bool status);
+
+        void enableBrakeLight(bool status);
 };
-
-
-class CoolingPump
-{
-    private:
-        bool isEnabled = true;
-        uint8_t pin;
-
-    public:
-        CoolingPump();
-        CoolingPump(uint8_t pinNum);
-
-        ~CoolingPump();
-
-        /**
-         * @brief Enables/disables the pump
-         * 
-         * @param status 
-         */
-        void enablePump(bool status);
-};
-
 
 class TSMS  //TSMS stands for "Tractive System Main Switch"
 {

--- a/MPU/include/gpioHW.h
+++ b/MPU/include/gpioHW.h
@@ -9,10 +9,15 @@
 #include <nerduino.h>
 
 #define CANMSG_PDU_ID 0x666
+#define BRAKELIGHT_WAIT_MS  250
 
 class PDU
 {
     private:
+
+        bool prev_brakelight_status = false;
+        Timer brakelight_timer;
+
         union
         {
             uint8_t msg[5] = {0, 0, 0, 0, 0};

--- a/MPU/include/gpioHW.h
+++ b/MPU/include/gpioHW.h
@@ -32,8 +32,6 @@ class PDU
             } fields;
         } pdu;
 
-        void sendPDUMsg();
-
     public:
         PDU();
 
@@ -46,6 +44,8 @@ class PDU
         void enableCoolingPump(bool status);
 
         void enableBrakeLight(bool status);
+
+        void sendPDUMsg();
 };
 
 extern PDU pdu;

--- a/MPU/include/gpioHW.h
+++ b/MPU/include/gpioHW.h
@@ -43,6 +43,8 @@ class PDU
         void enableBrakeLight(bool status);
 };
 
+extern PDU pdu;
+
 class TSMS  //TSMS stands for "Tractive System Main Switch"
 {
     private:

--- a/MPU/include/mpu.h
+++ b/MPU/include/mpu.h
@@ -24,6 +24,7 @@ extern WDT_T4<WDT1> wdt;
 
 extern bool isShutdown;
 extern bool ssReady;
+extern bool tsms_status;
 
 extern Timer canTest_wait;
 extern Timer spinningCheck_wait;

--- a/MPU/include/pedalHW.h
+++ b/MPU/include/pedalHW.h
@@ -78,26 +78,4 @@ class PedalHW
         FaultStatus_t isFaulted();
 };
 
-class BRAKELIGHT_HW
-{
-    private:
-        //Brake light writing timer
-        Timer brakeLightWait;
-        uint8_t brakeLightPin;
-
-    public:
-        BRAKELIGHT_HW();
-
-        BRAKELIGHT_HW(uint8_t pinNumber);
-
-        ~BRAKELIGHT_HW();
-
-        /**
-         * @brief Writes the brakelight to a specific state
-         * @note This function is intended to be activated constantly in the main loop, as the timing logic depends on retrying
-         * @param state 
-         */
-        void writeBrakeLight(bool state);
-};
-
 #endif

--- a/MPU/include/pedals.h
+++ b/MPU/include/pedals.h
@@ -11,6 +11,7 @@
 #include "mpuConfig.h"
 #include "cascadiamc.h"
 #include "orionbms.h"
+#include "gpioHW.h"
 #include "pedalHW.h"
 
 //Pins
@@ -28,11 +29,10 @@ class Pedals
 
         CascadiaMC *motorController;
         OrionBMS *bms;
+        PDU *pdu;
 
         PedalHW brakes;
         PedalHW accelerator;
-
-        BRAKELIGHT_HW brakeLight;
 
         uint8_t brakePins[2] = {BRAKE1_PIN, BRAKE2_PIN};
         uint8_t accelPins[2] = {ACCEL1_PIN, ACCEL2_PIN};
@@ -64,7 +64,7 @@ class Pedals
     public:
         Pedals();
 
-        Pedals(CascadiaMC *p_motorController, OrionBMS *p_bms);
+        Pedals(CascadiaMC *p_motorController, OrionBMS *p_bms, PDU *p_pdu);
 
         ~Pedals();
 

--- a/MPU/src/cascadiamc.cpp
+++ b/MPU/src/cascadiamc.cpp
@@ -92,17 +92,6 @@ uint16_t CascadiaMC::getTorque()
 }
 
 
-void CascadiaMC::clearFault()
-{
-    int time = millis() + 250;
-    while(millis() < time) {
-        sendMessageCAN1(CANMSG_MC_SETPARAMETER, 8, FAULT_CLEAR);
-        delay(5);
-    }
-    isFaulted = false;
-}
-
-
 void CascadiaMC::raiseFault()
 {
     if (isFaulted == false) {

--- a/MPU/src/driverio.cpp
+++ b/MPU/src/driverio.cpp
@@ -25,7 +25,7 @@ void DriverIO::handleReverse()
     motorController->setDirection(drive_state != REVERSE);
 }
 
-void DriverIO::handleButtonState()
+void DriverIO::handleButtonState(bool tsms_status)
 {
     bool state_changed = false;
 
@@ -33,7 +33,7 @@ void DriverIO::handleButtonState()
     incrButton.checkButtonPin();
     decrButton.checkButtonPin();
 
-    if (motorController->checkFault())
+    if (tsms_status == false)
     {
         motorController->setPower(false);
         mpu_state = FAULT;
@@ -130,6 +130,6 @@ void DriverIO::wheelIO_cb(const CAN_message_t &msg)
     wheelio.io.pot_l = SWITCHBYTES(wheelio.io.pot_l);
     wheelio.io.pot_r = SWITCHBYTES(wheelio.io.pot_r);
 
-    incrButton.setButtonState(wheelio.io.button2);
-    decrButton.setButtonState(wheelio.io.button4);
+    decrButton.setButtonState(wheelio.io.button2);
+    incrButton.setButtonState(wheelio.io.button4);
 }

--- a/MPU/src/gpio.cpp
+++ b/MPU/src/gpio.cpp
@@ -1,16 +1,19 @@
 #include "gpio.h"
 
+PDU pdu;
+
 GPIO::GPIO(){}
 
 
-GPIO::GPIO(CascadiaMC *p_motorController, OrionBMS *p_bms)
+GPIO::GPIO(CascadiaMC *p_motorController, OrionBMS *p_bms, PDU *p_pdu)
 {
-    radiatorFan = RadiatorFan(RADIATORFAN_PIN);
-    coolingPump = CoolingPump(PUMP_PIN);
     tsms = TSMS(SS_READY_SEN);
 
     motorController = p_motorController;
     bms = p_bms;
+    pdu = p_pdu;
+
+    pdu->enableAccFans(true, true);
 }
 
 
@@ -36,12 +39,12 @@ bool GPIO::handleTSMS()
 
 void GPIO::handlePump()
 {
-    coolingPump.enablePump(motorController->getIsOn());
+    pdu->enableCoolingPump(motorController->getIsOn());
 }
 
 void GPIO::handleRadiatorFan()
 {
     int16_t temp = motorController->getRadiatorTemp() / 10;
 
-    radiatorFan.enableFan(temp > MAX_FANSPEED_TEMP);
+    pdu->enableRadiatorFan(temp > MAX_FANSPEED_TEMP);
 }

--- a/MPU/src/gpio.cpp
+++ b/MPU/src/gpio.cpp
@@ -20,21 +20,10 @@ GPIO::GPIO(CascadiaMC *p_motorController, OrionBMS *p_bms, PDU *p_pdu)
 GPIO::~GPIO(){}
 
 
-bool GPIO::handleTSMS()
+bool GPIO::getTSMS()
 {
     // Serial.println(tsms.isReady());
-    if(!tsms.isReady())
-    {
-        motorController->raiseFault();
-        return false;
-    }
-    if(tsms.isPowerCycled() && tsms.isReady())
-    {
-        motorController->clearFault();
-        Serial.println("Clearing!");
-        return true;
-    }
-    return false;
+    return tsms.isReady();
 }
 
 void GPIO::handlePump()

--- a/MPU/src/gpioHW.cpp
+++ b/MPU/src/gpioHW.cpp
@@ -30,8 +30,15 @@ void PDU::enableCoolingPump(bool status)
 
 void PDU::enableBrakeLight(bool status)
 {
+    if (!brakelight_timer.isTimerExpired() && prev_brakelight_status == true)
+        return;
+
     pdu.fields.brake_light = status;
     sendPDUMsg();
+
+    if (status == true) brakelight_timer.startTimer(BRAKELIGHT_WAIT_MS);
+
+    prev_brakelight_status = status;
 }
 
 TSMS::TSMS(){}

--- a/MPU/src/gpioHW.cpp
+++ b/MPU/src/gpioHW.cpp
@@ -12,20 +12,17 @@ void PDU::sendPDUMsg()
 void PDU::enableRadiatorFan(bool status)
 {
     pdu.fields.radiator_fan_dty = status;
-    sendPDUMsg();
 }
 
 void PDU::enableAccFans(bool r_status, bool l_status)
 {
     pdu.fields.right_acc_fan = r_status;
     pdu.fields.left_acc_fan = l_status;
-    sendPDUMsg();
 }
 
 void PDU::enableCoolingPump(bool status)
 {
     pdu.fields.cooling_pump = status;
-    sendPDUMsg();
 }
 
 void PDU::enableBrakeLight(bool status)
@@ -34,7 +31,6 @@ void PDU::enableBrakeLight(bool status)
         return;
 
     pdu.fields.brake_light = status;
-    sendPDUMsg();
 
     if (status == true) brakelight_timer.startTimer(BRAKELIGHT_WAIT_MS);
 

--- a/MPU/src/gpioHW.cpp
+++ b/MPU/src/gpioHW.cpp
@@ -1,40 +1,38 @@
 #include "gpioHW.h"
 
-RadiatorFan::RadiatorFan(){}
+PDU::PDU(){}
 
-RadiatorFan::RadiatorFan(uint8_t pinNum)
+PDU::~PDU(){}
+
+void PDU::sendPDUMsg()
 {
-    pin = pinNum;
-    pinMode(pin, OUTPUT);
-    enableFan(false);
+    sendMessageCAN1(CANMSG_PDU_ID, 4, pdu.msg);
 }
 
-RadiatorFan::~RadiatorFan(){}
-
-void RadiatorFan::enableFan(bool status)
+void PDU::enableRadiatorFan(bool status)
 {
-    isEnabled = status;
-    digitalWrite(pin, isEnabled);
+    pdu.fields.radiator_fan_dty = status;
+    sendPDUMsg();
 }
 
-
-CoolingPump::CoolingPump(){}
-
-CoolingPump::CoolingPump(uint8_t pinNum)
+void PDU::enableAccFans(bool r_status, bool l_status)
 {
-    pin = pinNum;
-    pinMode(pin, OUTPUT);
-    enablePump(false);
+    pdu.fields.right_acc_fan = r_status;
+    pdu.fields.left_acc_fan = l_status;
+    sendPDUMsg();
 }
 
-CoolingPump::~CoolingPump(){}
-
-void CoolingPump::enablePump(bool status)
+void PDU::enableCoolingPump(bool status)
 {
-    isEnabled = status;
-    digitalWrite(pin, isEnabled);
+    pdu.fields.cooling_pump = status;
+    sendPDUMsg();
 }
 
+void PDU::enableBrakeLight(bool status)
+{
+    pdu.fields.brake_light = status;
+    sendPDUMsg();
+}
 
 TSMS::TSMS(){}
 

--- a/MPU/src/main.cpp
+++ b/MPU/src/main.cpp
@@ -22,9 +22,10 @@ void setup()
     wdt.begin(config);
     Serial.begin(57600);
 
-    pedals = Pedals(&motorController, &bms);
+    pdu = PDU();
+    pedals = Pedals(&motorController, &bms, &pdu);
     driverio = DriverIO(&motorController, &bms);
-    gpio = GPIO(&motorController, &bms);
+    gpio = GPIO(&motorController, &bms, &pdu);
     pinMode(RELAY_PIN, OUTPUT);
     writeFaultLatch(NOT_FAULTED);
 

--- a/MPU/src/main.cpp
+++ b/MPU/src/main.cpp
@@ -42,6 +42,7 @@ void loop()
     driverioProcess();
     pedalsProcess();
     motorController.writeMCState();
+    pdu.sendPDUMsg();
     checkShutdownStatus();
     sendMPUStatus();
     wdt.feed();

--- a/MPU/src/mpu.cpp
+++ b/MPU/src/mpu.cpp
@@ -8,13 +8,14 @@ OrionBMS bms;
 WDT_T4<WDT1> wdt;
 bool isShutdown = false;
 bool ssReady = false;
+bool tsms_status = false;
 Timer canTest_wait;
 Timer spinningCheck_wait;
 
 void driverioProcess()
 {
     // Serial.println("DriverIO process...");
-    driverio.handleButtonState();
+    driverio.handleButtonState(tsms_status);
     driverio.handleReverse();
     driverio.handleSpeaker();
 }
@@ -42,7 +43,7 @@ void pedalsProcess()
 
 void gpioProcess()
 {
-    bool faultReset = gpio.handleTSMS();
+    tsms_status = gpio.getTSMS();
     gpio.handlePump();
     gpio.handleRadiatorFan();
 

--- a/MPU/src/pedalHW.cpp
+++ b/MPU/src/pedalHW.cpp
@@ -66,27 +66,3 @@ FaultStatus_t PedalHW::isFaulted()
 {
     return readingFault;
 }
-
-
-BRAKELIGHT_HW::BRAKELIGHT_HW(){}
-
-BRAKELIGHT_HW::~BRAKELIGHT_HW(){}
-
-BRAKELIGHT_HW::BRAKELIGHT_HW(uint8_t pinNumber)
-{
-    brakeLightPin = pinNumber;
-    pinMode(pinNumber, OUTPUT);
-	digitalWrite(pinNumber, HIGH);
-}
-
-void BRAKELIGHT_HW::writeBrakeLight(bool state)
-{
-    if(brakeLightWait.isTimerExpired())
-    {
-        digitalWrite(brakeLightPin, state);
-        if(state == HIGH)
-        {
-            brakeLightWait.startTimer(BRAKELIGHT_MIN_TIME_ON);
-        }
-    }
-}

--- a/MPU/src/pedals.cpp
+++ b/MPU/src/pedals.cpp
@@ -4,17 +4,16 @@
 Pedals::Pedals(){}
 
 
-Pedals::Pedals(CascadiaMC *p_motorController, OrionBMS *p_bms)
+Pedals::Pedals(CascadiaMC *p_motorController, OrionBMS *p_bms, PDU *p_pdu)
 {
-	pinMode(BRAKELIGHT_PIN, OUTPUT);
-	digitalWrite(BRAKELIGHT_PIN, HIGH);
-
 	motorController = p_motorController;
 	bms = p_bms;
+	pdu = p_pdu;
+
+	pdu->enableBrakeLight(brakePressed);
 
 	accelerator = PedalHW(ACCELERATOR_ERROR_PERCENT, MAX_ACCEL_ERRORS, accelPins);
 	brakes = PedalHW(BRAKES_ERROR_PERCENT, MAX_BRAKE_ERRORS, brakePins);
-	brakeLight = BRAKELIGHT_HW(BRAKELIGHT_PIN);
 }
 
 
@@ -75,7 +74,7 @@ FaultStatus_t Pedals::readBrake()
 	//Set brakePressed to whether or not the brake value is greater than the braking threshold
 	brakePressed = pedalVal > ANALOG_BRAKE_THRESH ? HIGH : LOW;
 
-	brakeLight.writeBrakeLight(brakePressed);
+	pdu->enableBrakeLight(brakePressed);
 
 	return brakes.isFaulted();
 }


### PR DESCRIPTION
Linking to #12, basically I just created a PDU object that contains all the functionality of the PDU as its interface, and then changed other objects to utilize that interface (`Pedals` and `GPIO`).

Side note: Since the GPIO class was kinda meant to handle all the PDU functionality, we might want to consider removing the GPIO entirely and making TSMS and PDU their own stand out classes, but that is probably too much scope for this ticket